### PR TITLE
Ci/fix macos wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-14]
+        cibw_python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
       - name: Checkout code
@@ -34,10 +35,11 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "${{ matrix.cibw_python }}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD_FRONTEND: "build"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           # SEC-D04: Pin all build dependencies to exact versions
           # to prevent supply chain attacks via compromised build tools.
           CIBW_BEFORE_BUILD_LINUX: >
@@ -50,7 +52,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.cibw_python }}
           path: ./wheelhouse/*.whl
           retention-days: 7
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          MACOSX_DEPLOYMENT_TARGET: "10.14"
           CIBW_BUILD: "${{ matrix.cibw_python }}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
+          MACOSX_DEPLOYMENT_TARGET: "10.14"
           CIBW_BUILD: "${{ matrix.cibw_python }}-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 pp*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD_FRONTEND: "build"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
-          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.14"
           # SEC-D04: Pin all build dependencies to exact versions
           # to prevent supply chain attacks via compromised build tools.
           CIBW_BEFORE_BUILD_LINUX: >

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -40,6 +40,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BUILD_FRONTEND: "build"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.14"
           # SEC-D04: Pin all build dependencies to exact versions
           # to prevent supply chain attacks via compromised build tools.
           CIBW_BEFORE_BUILD_LINUX: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,11 @@
 cmake_minimum_required(VERSION 3.21)
+
+if(APPLE)
+  # Force macOS deployment target to 10.14 (Mojave) to support C++17 aligned allocation
+  # required by nanobind. This overrides cibuildwheel's default 10.9 target.
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum OS X deployment version" FORCE)
+endif()
+
 project(fasteda VERSION 0.1.0 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,14 +60,19 @@ set(FASTEDA_SOURCES
 if(MSVC)
   # MSVC: /arch:AVX2 enables AVX2 + FMA3 intrinsics.
   # AVX-512 intrinsics are available via <immintrin.h> without a separate flag.
-  set_source_files_properties(src/core/simd_scanner.cpp
-    PROPERTIES COMPILE_FLAGS "/arch:AVX2"
-  )
+  set(SIMD_COMPILE_FLAGS "/arch:AVX2")
 else()
   # GCC/Clang: -mavx2 enables AVX2, -mavx512f + -mavx512bw enables AVX-512
   # -mpopcnt ensures _mm_popcnt_u32 is available (used by some SIMD patterns)
+  set(SIMD_COMPILE_FLAGS "-mavx2 -mavx512f -mavx512bw -mpopcnt")
+  if(CMAKE_OSX_ARCHITECTURES MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+    set(SIMD_COMPILE_FLAGS "")
+  endif()
+endif()
+
+if(SIMD_COMPILE_FLAGS)
   set_source_files_properties(src/core/simd_scanner.cpp
-    PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512f -mavx512bw -mpopcnt"
+    PROPERTIES COMPILE_FLAGS "${SIMD_COMPILE_FLAGS}"
   )
 endif()
 
@@ -105,15 +110,10 @@ if(NOT SKBUILD)
   target_compile_definitions(fasteda_bench PRIVATE FASTEDA_STANDALONE)
   target_link_libraries(fasteda_bench PRIVATE Threads::Threads)
   # Apply SIMD flags to simd_scanner.cpp inside the bench target too
-  if(MSVC)
+  if(SIMD_COMPILE_FLAGS)
     set_source_files_properties(src/core/simd_scanner.cpp
       TARGET_DIRECTORY fasteda_bench
-      PROPERTIES COMPILE_FLAGS "/arch:AVX2"
-    )
-  else()
-    set_source_files_properties(src/core/simd_scanner.cpp
-      TARGET_DIRECTORY fasteda_bench
-      PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512f -mavx512bw -mpopcnt"
+      PROPERTIES COMPILE_FLAGS "${SIMD_COMPILE_FLAGS}"
     )
   endif()
 
@@ -123,15 +123,10 @@ if(NOT SKBUILD)
       tests/cpp/test_simd_scanner.cpp
   )
   target_include_directories(test_simd_scanner PRIVATE ${CMAKE_SOURCE_DIR}/include)
-  if(MSVC)
+  if(SIMD_COMPILE_FLAGS)
     set_source_files_properties(src/core/simd_scanner.cpp
       TARGET_DIRECTORY test_simd_scanner
-      PROPERTIES COMPILE_FLAGS "/arch:AVX2"
-    )
-  else()
-    set_source_files_properties(src/core/simd_scanner.cpp
-      TARGET_DIRECTORY test_simd_scanner
-      PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512f -mavx512bw -mpopcnt"
+      PROPERTIES COMPILE_FLAGS "${SIMD_COMPILE_FLAGS}"
     )
   endif()
 
@@ -158,15 +153,10 @@ if(NOT SKBUILD)
   )
   target_include_directories(test_stream_reader PRIVATE ${CMAKE_SOURCE_DIR}/include)
   target_link_libraries(test_stream_reader PRIVATE Threads::Threads)
-  if(MSVC)
+  if(SIMD_COMPILE_FLAGS)
     set_source_files_properties(src/core/simd_scanner.cpp
       TARGET_DIRECTORY test_stream_reader
-      PROPERTIES COMPILE_FLAGS "/arch:AVX2"
-    )
-  else()
-    set_source_files_properties(src/core/simd_scanner.cpp
-      TARGET_DIRECTORY test_stream_reader
-      PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512f -mavx512bw -mpopcnt"
+      PROPERTIES COMPILE_FLAGS "${SIMD_COMPILE_FLAGS}"
     )
   endif()
 
@@ -179,15 +169,10 @@ if(NOT SKBUILD)
   )
   target_include_directories(test_debug_crash PRIVATE ${CMAKE_SOURCE_DIR}/include)
   target_link_libraries(test_debug_crash PRIVATE Threads::Threads)
-  if(MSVC)
+  if(SIMD_COMPILE_FLAGS)
     set_source_files_properties(src/core/simd_scanner.cpp
       TARGET_DIRECTORY test_debug_crash
-      PROPERTIES COMPILE_FLAGS "/arch:AVX2"
-    )
-  else()
-    set_source_files_properties(src/core/simd_scanner.cpp
-      TARGET_DIRECTORY test_debug_crash
-      PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512f -mavx512bw -mpopcnt"
+      PROPERTIES COMPILE_FLAGS "${SIMD_COMPILE_FLAGS}"
     )
   endif()
 
@@ -204,15 +189,10 @@ if(NOT SKBUILD)
   )
   target_include_directories(test_profile_builder PRIVATE ${CMAKE_SOURCE_DIR}/include)
   target_link_libraries(test_profile_builder PRIVATE Threads::Threads)
-  if(MSVC)
+  if(SIMD_COMPILE_FLAGS)
     set_source_files_properties(src/core/simd_scanner.cpp
       TARGET_DIRECTORY test_profile_builder
-      PROPERTIES COMPILE_FLAGS "/arch:AVX2"
-    )
-  else()
-    set_source_files_properties(src/core/simd_scanner.cpp
-      TARGET_DIRECTORY test_profile_builder
-      PROPERTIES COMPILE_FLAGS "-mavx2 -mavx512f -mavx512bw -mpopcnt"
+      PROPERTIES COMPILE_FLAGS "${SIMD_COMPILE_FLAGS}"
     )
   endif()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,13 @@ sdist.exclude       = [
 [tool.scikit-build.cmake.define]
 FETCHCONTENT_UPDATES_DISCONNECTED = "ON"
 
+# ── cibuildwheel ─────────────────────────────────────────────────
+# nanobind uses C++17 aligned-deallocation which requires macOS 10.14+.
+# Setting this here ensures cibuildwheel passes it to every inner
+# virtualenv it creates, overriding the default of 10.9 / 11.0.
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }
+
 # ── pytest ───────────────────────────────────────────────────────
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/core/simd_scanner.cpp
+++ b/src/core/simd_scanner.cpp
@@ -25,12 +25,14 @@
 #include <cstring>   // memset
 
 // ── Intrinsic headers ─────────────────────────────────────────────────────────
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #if defined(_MSC_VER)
 #  include <intrin.h>          // __cpuid, __cpuidex
 #  include <immintrin.h>       // AVX2 / AVX-512 intrinsics
 #elif defined(__GNUC__) || defined(__clang__)
 #  include <immintrin.h>       // AVX2 / AVX-512
 #  include <cpuid.h>           // __get_cpuid_count (fallback)
+#endif
 #endif
 
 namespace zedda {
@@ -42,6 +44,7 @@ namespace zedda {
 // ─────────────────────────────────────────────────────────────────────────────
 
 bool has_avx2() noexcept {
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_cpu_supports("avx2");
 #elif defined(_MSC_VER)
@@ -52,9 +55,13 @@ bool has_avx2() noexcept {
 #else
     return false;  // unknown compiler — safe fallback
 #endif
+#else
+    return false;
+#endif
 }
 
 bool has_avx512f() noexcept {
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
 #if defined(__GNUC__) || defined(__clang__)
     // AVX-512F: leaf 7.0 EBX bit 16; AVX-512BW: leaf 7.0 EBX bit 30
     // We need both for byte-level 512-bit comparisons
@@ -65,6 +72,9 @@ bool has_avx512f() noexcept {
     bool f   = (info[1] & (1 << 16)) != 0;  // AVX-512F
     bool bw  = (info[1] & (1 << 30)) != 0;  // AVX-512BW
     return f && bw;
+#else
+    return false;
+#endif
 #else
     return false;
 #endif


### PR DESCRIPTION
## Description
This PR fixes multiple fatal compilation errors that were preventing macOS wheels (both Intel and Apple Silicon) from building successfully, and significantly speeds up the GitHub Actions CI pipeline. 

With this PR merged, creating a new release will successfully build and publish binary wheels for all platforms, allowing end-users to run `pip install zedda` without needing CMake or C++ build tools installed on their machines.

## Key Changes

###  CI Speed & Matrix Optimization (`build_wheels.yml`)
- **Matrix Parallelization:** Sped up the `cibuildwheel` workflow by distributing it across a matrix of 5 Python versions (`cp39` through `cp313`). Instead of waiting for a single runner to build all versions sequentially, GitHub now spawns 15 runners simultaneously, massively reducing CI completion time and making debugging easier.

###  Apple Silicon (ARM64) Crash Fix (`simd_scanner.cpp`)
- **Architecture Guards:** Fixed a fatal compiler crash on `macos-14` where Apple Clang encountered Intel-exclusive AVX headers (`<immintrin.h>`). Wrapped all x86-specific headers and `__builtin_cpu_supports` calls inside architecture macros (`#if defined(__x86_64__)`). ARM64 builds now safely ignore Intel intrinsics and fall back to the scalar implementation.

###  Dynamic CMake SIMD Flags (`CMakeLists.txt`)
- **Safe Compilation:** CMake no longer unconditionally passes Intel flags (`-mavx2` and `-mavx512f`) on macOS. It now dynamically checks `CMAKE_OSX_ARCHITECTURES` and `CMAKE_SYSTEM_PROCESSOR` and strips AVX flags when compiling for `arm64`.

###  macOS C++17 Target Fix (`CMakeLists.txt` & `pyproject.toml`)
- **`nanobind` Compatibility:** Fixed an `operator delete` compilation failure in `nb_type.cpp`. `cibuildwheel` was forcing the macOS deployment target to `10.9` (2013), but `nanobind` requires C++17 aligned allocation (introduced in `10.14`).
- **Enforced 10.14 Target:** Explicitly forced `set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" ... FORCE)` inside the root `CMakeLists.txt` to completely override `cibuildwheel`'s default behavior, and synced `pyproject.toml` environment settings.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD update (workflow optimizations)

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have verified the GitHub Actions workflows pass completely
- [x] All new and existing tests passed
